### PR TITLE
Insider: Add instructions for how to revert Insider to public build

### DIFF
--- a/en/Advanced topics/Insider builds.md
+++ b/en/Advanced topics/Insider builds.md
@@ -51,6 +51,6 @@ To change back to using public (non-Insider) builds on desktop:
 2. Close Obsidian.
 3. Delete the `obsidian-VERSION.asar` file, where `VERSION` is the Obsidian version.
    - Windows: `%APPDATA%\obsidian\obsidian-VERSION.asar`
-   - Mac: `~/Library/Application Support/obsidian/obsidian-0.xx.xx.asar`
+   - Mac: `~/Library/Application Support/obsidian/obsidian-VERSION.asar`
    - Linux: `~/.config/obsidian/obsidian-0.xx.xx.asar`
 4. Restart Obsidian.

--- a/en/Advanced topics/Insider builds.md
+++ b/en/Advanced topics/Insider builds.md
@@ -39,3 +39,18 @@ To report an issue, please use one of the following channels:
 - In the forum, create a new topic under [Bug reports](https://forum.obsidian.md/c/bug-reports/7).
 
 When you report an issue, include the build version and the OS you're running it on. You can find the build version under **Settings > About > App > Current version**.
+
+## Go back to public builds on desktop
+
+To go back to using the public (non-Insider) builds on desktop:
+
+1. Disable Insider builds
+    1. Open **Settings**.
+    2. In the sidebar, select **About**.
+    3. Under **App**, disable **Receive insider builds**.
+2. Close Obsidian.
+3. Delete the file named `x.xx.xx.asar` (where the `x`s stand for numbers):
+   - Windows: `%APPDATA%\obsidian\obsidian-0.xx.xx.asar`
+   - Mac: `~/Library/Application Support/obsidian/obsidian-0.xx.xx.asar`
+   - Linux: `~/.config/obsidian/obsidian-0.xx.xx.asar`
+4. Restart Obsidian.

--- a/en/Advanced topics/Insider builds.md
+++ b/en/Advanced topics/Insider builds.md
@@ -44,7 +44,7 @@ When you report an issue, include the build version and the OS you're running it
 
 To change back to using public (non-Insider) builds on desktop:
 
-1. Disable Insider builds
+1. Disable Insider builds.
     1. Open **Settings**.
     2. In the sidebar, select **About**.
     3. Under **App**, disable **Receive insider builds**.

--- a/en/Advanced topics/Insider builds.md
+++ b/en/Advanced topics/Insider builds.md
@@ -52,5 +52,5 @@ To change back to using public (non-Insider) builds on desktop:
 3. Delete the `obsidian-VERSION.asar` file, where `VERSION` is the Obsidian version.
    - Windows: `%APPDATA%\obsidian\obsidian-VERSION.asar`
    - Mac: `~/Library/Application Support/obsidian/obsidian-VERSION.asar`
-   - Linux: `~/.config/obsidian/obsidian-0.xx.xx.asar`
+   - Linux: `~/.config/obsidian/obsidian-VERSION.asar`
 4. Restart Obsidian.

--- a/en/Advanced topics/Insider builds.md
+++ b/en/Advanced topics/Insider builds.md
@@ -40,7 +40,7 @@ To report an issue, please use one of the following channels:
 
 When you report an issue, include the build version and the OS you're running it on. You can find the build version under **Settings > About > App > Current version**.
 
-## Go back to public builds on desktop
+## Change back to public builds on desktop
 
 To go back to using the public (non-Insider) builds on desktop:
 

--- a/en/Advanced topics/Insider builds.md
+++ b/en/Advanced topics/Insider builds.md
@@ -50,7 +50,7 @@ To change back to using public (non-Insider) builds on desktop:
     3. Under **App**, disable **Receive insider builds**.
 2. Close Obsidian.
 3. Delete the `obsidian-VERSION.asar` file, where `VERSION` is the Obsidian version.
-   - Windows: `%APPDATA%\obsidian\obsidian-0.xx.xx.asar`
+   - Windows: `%APPDATA%\obsidian\obsidian-VERSION.asar`
    - Mac: `~/Library/Application Support/obsidian/obsidian-0.xx.xx.asar`
    - Linux: `~/.config/obsidian/obsidian-0.xx.xx.asar`
 4. Restart Obsidian.

--- a/en/Advanced topics/Insider builds.md
+++ b/en/Advanced topics/Insider builds.md
@@ -49,7 +49,7 @@ To change back to using public (non-Insider) builds on desktop:
     2. In the sidebar, select **About**.
     3. Under **App**, disable **Receive insider builds**.
 2. Close Obsidian.
-3. Delete the file named `x.xx.xx.asar` (where the `x`s stand for numbers):
+3. Delete the `obsidian-VERSION.asar` file, where `VERSION` is the Obsidian version.
    - Windows: `%APPDATA%\obsidian\obsidian-0.xx.xx.asar`
    - Mac: `~/Library/Application Support/obsidian/obsidian-0.xx.xx.asar`
    - Linux: `~/.config/obsidian/obsidian-0.xx.xx.asar`

--- a/en/Advanced topics/Insider builds.md
+++ b/en/Advanced topics/Insider builds.md
@@ -42,7 +42,7 @@ When you report an issue, include the build version and the OS you're running it
 
 ## Change back to public builds on desktop
 
-To go back to using the public (non-Insider) builds on desktop:
+To change back to using public (non-Insider) builds on desktop:
 
 1. Disable Insider builds
     1. Open **Settings**.


### PR DESCRIPTION
I've adapted these instructions from Carl's "rollback insider" trigger on Discord. I've never rolled back from Insider myself.

The instructions for finding the asar file should be more user-friendly, but at least they exist.