### PR TITLE
Clarify and improve SEO for negation in search

### DIFF
--- a/en/Plugins/Search.md
+++ b/en/Plugins/Search.md
@@ -31,6 +31,10 @@ To exclude a word from the search results, add a hyphen (`-`) in front of it:
 
 - `meeting -work` returns files that contain `meeting` but not `work`.
 
+The technical term for excluding words is to "negate" or "negation". You can negate any expression or any group of expressions using parentheses.
+
+- `meeting -(work OR meetup)` returns files that contain `meeting` but do not contain `work` or `meetup`.
+
 > [!tip] Explain search term
 > If you need to troubleshoot a complex search term, you can click **Explain search term** in the Search pane for an explanation of your search term.
 

--- a/en/Plugins/Search.md
+++ b/en/Plugins/Search.md
@@ -27,7 +27,7 @@ You can use parentheses to control the priority of each expression.
 
 - `meeting (work OR meetup) personal` returns files that contain `meeting`, `personal`, and either `work` or `meetup`.
 
-To exclude or _negate_ a word from the search results, add a hyphen (`-`) in front of it:
+To exclude, or _negate_, a word from the search results, add a hyphen (`-`) in front of it:
 
 - `meeting -work` returns files that contain `meeting` but not `work`.
 

--- a/en/Plugins/Search.md
+++ b/en/Plugins/Search.md
@@ -27,7 +27,7 @@ You can use parentheses to control the priority of each expression.
 
 - `meeting (work OR meetup) personal` returns files that contain `meeting`, `personal`, and either `work` or `meetup`.
 
-To exclude, or _negate_, a word from the search results, add a hyphen (`-`) in front of it:
+To exclude, or negate, a word from the search results, add a hyphen (`-`) in front of it:
 
 - `meeting -work` returns files that contain `meeting` but not `work`.
 

--- a/en/Plugins/Search.md
+++ b/en/Plugins/Search.md
@@ -27,13 +27,17 @@ You can use parentheses to control the priority of each expression.
 
 - `meeting (work OR meetup) personal` returns files that contain `meeting`, `personal`, and either `work` or `meetup`.
 
-To exclude a word from the search results, add a hyphen (`-`) in front of it:
+To exclude or _negate_ a word from the search results, add a hyphen (`-`) in front of it:
 
 - `meeting -work` returns files that contain `meeting` but not `work`.
 
-The technical term for excluding words is to "negate" or "negation". You can negate any expression or any group of expressions using parentheses.
+You can exclude multiple expressions:
 
-- `meeting -(work OR meetup)` returns files that contain `meeting` but do not contain `work` or `meetup`.
+- `meeting -work -meetup` returns files that contain `meeting` but not `work` or `meetup`.
+
+You can exclude a combination of expressions using parentheses:
+
+- `meeting -(work meetup)` returns files that contain `meeting` but not _both_ `work` and `meetup`.
 
 > [!tip] Explain search term
 > If you need to troubleshoot a complex search term, you can click **Explain search term** in the Search pane for an explanation of your search term.


### PR DESCRIPTION
The Search page did not use the term "negate" or "negation" which is a term people will use to find this feature.

I also added an example of negating an OR expression in parentheses.
