### PR TITLE
Update publish custom domain instructions to include host rewrite for nginx.

### DIFF
--- a/en/Obsidian Publish/Set up a custom domain.md
+++ b/en/Obsidian Publish/Set up a custom domain.md
@@ -64,6 +64,7 @@ In your NGINX configuration, add the following:
 location /my-notes {
   proxy_pass https://publish.obsidian.md/serve?url=mysite.com/my-notes/;
   proxy_ssl_server_name on;
+  proxy_set_header Host publish.obsidian.md;
 }
 ```
 


### PR DESCRIPTION
Without this, some users might run into 421 errors generated by Cloudflare.