### PR TITLE
Adjust punctuation, wording, and grammar under /en/

### DIFF
--- a/en/Editing and formatting/Basic formatting syntax.md
+++ b/en/Editing and formatting/Basic formatting syntax.md
@@ -213,17 +213,25 @@ You can create an unordered list by adding a `-`, `*`, or `+` before the text.
 - Second list item
 - Third list item
 
-To create an ordered list, start each line with a number followed by a `.` symbol.
+To create an ordered list, start each line with a number followed by a `.` or `)` symbol.
 
 ```md
 1. First list item
 2. Second list item
 3. Third list item
+
+4) Fourth list item
+5) Fifth list item
+6) Sixth list item
 ```
 
 1. First list item
 2. Second list item
 3. Third list item
+
+4) Fourth list item
+5) Fifth list item
+6) Sixth list item
 
 You can create a nested list by indenting one of more list items.
 

--- a/en/Getting started/Create a vault.md
+++ b/en/Getting started/Create a vault.md
@@ -16,9 +16,9 @@ To create a new empty vault:
 If you already have a folder that you want to use as your vault:
 
 1. To the right of **Open folder as vault**, click **Open**.
-2. In the file browser, select the folder you want to use as your vault.
+2. In your file browser, select the folder you want to use as your vault.
 3. Click **Open**.
 
-If you want to know more about how vaults work, learn how [[How Obsidian stores data]].
+If you want to know more about how vaults work, learn [[How Obsidian stores data|how Obsidian stores data]].
 
-Now that you've set up your vault, you're ready to [[Create your first note]].
+Now that you've set up your vault, you're ready to [[Create your first note|create your first note]].

--- a/en/Getting started/Create your first note.md
+++ b/en/Getting started/Create your first note.md
@@ -26,7 +26,7 @@ Obsidian also supports [Markdown](https://en.wikipedia.org/wiki/Markdown)—a ma
 
 2. In your note, select the text "knowledge base" and press `Ctrl+B` (or `Cmd+B` on macOS) to make it bold.
 
-To learn more about how to format your notes using Markdown, refer to [[Basic formatting syntax]].
+To learn more about how to format your notes using Markdown, refer to the [[Basic formatting syntax|formatting syntax]].
 
 ## Learn more
 

--- a/en/Getting started/Sync your notes across devices.md
+++ b/en/Getting started/Sync your notes across devices.md
@@ -96,7 +96,7 @@ We understand that many of you use other services for syncing files and you'd pr
 
 Obsidian works differently from other Markdown editors on iOS. Editors such as 1Writer and iA Writer access one note at a time, which lets them use built-in support for documents.
 
-In contrast, many features in Obsidian need access to your entire vault. For example if you rename a file, then Obsidian needs to update all files in the vault that links to that file.
+In contrast, many features in Obsidian need access to your entire vault. For example, if you rename a file, then Obsidian needs to update all files in the vault that links to that file.
 
 Implementing a system to read, modify, and monitor an entire folder structure comprising of possibly thousand of notes outside of the supported locations is challenging. We hope to address this limitation in the future.
 

--- a/en/Obsidian/Android app.md
+++ b/en/Obsidian/Android app.md
@@ -15,4 +15,4 @@ The two biggest roadblocks are:
 - Scoped storage performs many extra permission checks for every single file access, causing significant performance degradation when opening and using Obsidian.
 - Scoped storage doesn't provide a way to watch for external changes, which is critical when using Obsidian with a third-party syncing tool.
 
-Google specifically gives instructions for developers of this kind of apps a special permission. Obsidian belongs to two categories in the list of exceptions: "document management apps", and "on-device file search". [Read more about it here.](https://developer.android.com/training/data-storage/manage-all-files)
+Google specifically gives instructions for developers of this kind of apps a special permission. Obsidian belongs to two categories in the list of exceptions: "document management apps" and "on-device file search". [Read more about it here.](https://developer.android.com/training/data-storage/manage-all-files)

--- a/en/User interface/Workspace/Ribbon.md
+++ b/en/User interface/Workspace/Ribbon.md
@@ -22,4 +22,4 @@ You can rearrange the order of ribbon actions by dragging and dropping the icons
 
 To hide certain actions, you can right click on empty space on the ribbon and uncheck certain actions to hide them.
 
-Ribbon layout will be remembered across sessions. It will get synchronized to other devices and mobile app if app settings, specifically the `workspace.json` file, is synchronized.
+Ribbon layout will be remembered across sessions. It will get synced to other devices and mobile app if app settings, specifically the `workspace.json` file, is synced.


### PR DESCRIPTION
## Slight punctuation, wording, and grammatical changes under /en/ . 

**Files changed:**
- en/Editing and formatting/Basic formatting syntax.md
     - Ordered lists are also able to be made using a `)` after a number (wasn't sure if this warranted opening an issue)
- en/Getting started/Create a vault.md
- en/Getting started/Create your first note.md
- en/Getting started/Sync your notes across devices.md
- en/Obsidian/Android app.md
- en/User interface/Workspace/Ribbon.md