### PR TITLE
Tweak tab navigation hotkeys

### DIFF
--- a/en/User interface/Use tabs in Obsidian.md
+++ b/en/User interface/Use tabs in Obsidian.md
@@ -77,13 +77,14 @@ To unpin a pinned tab, right-click the tab and select **Unpin**.
 
 Select a tab to switch to it. Or, use a keyboard shortcut:
 
-- Press `Ctrl+Tab` to switch to the next tab.
-- Press `Ctrl+Shift+Tab` to switch to the previous tab.
-- Press `Ctrl+1` to switch to the first tab on the left.
-- Press `Ctrl` together with any number from `2` to `8` to switch to that tab.
-- Press `Ctrl+9` to open the last tab on the right regardless of how many tabs you have.
-
-To open and switch to a recently closed tab, press `Ctrl+Shift+t` (or `Cmd+Shift+t` on macOS).
+| Switch To                 | MacOS            | Windows/Linux        |
+|---------------------------|------------------|----------------------|
+| **Next tab**              | `⌃`+`⇥`         | `Ctrl`+`Tab`         |
+| **Previous tab**          | `⌃`+`⇧`+`⇥`    | `Ctrl`+`Shift`+`Tab` |
+| **First tab on the left** | `⌘`+`1`          | `Ctrl`+`1`           |
+| **2nd to 8th tab**        | `⌘`+`2`..`8`     | `Ctrl`+`2`..`8`      |
+| **Last tab on the right** | `⌘`+`9`          | `Ctrl`+`9`           |
+| **Recently closed tab**   | `⌘`+`⇧`+`t`     | `Ctrl`+`Shift`+`t`   |
 
 ## Stack tab groups
 


### PR DESCRIPTION
On the `Use tabs in Obsidian` page, the switch tabs hotkeys section has been tweaked to fix some inaccuracies. The old wording was unclear about how tab navigation hotkeys should to work on macOS. On Windows all combinations use `Ctrl` key, but on Mac some uses `Cmd`, some `Ctrl`.