### PR TITLE
Introduces Customize navigation guide

### DIFF
--- a/en/Obsidian Publish/Customize your site.md
+++ b/en/Obsidian Publish/Customize your site.md
@@ -55,3 +55,53 @@ To use one of the community themes for your site:
 You can toggle several UI features for your site, such as the graph view or a table of contents.
 
 Browse the available UI features under the **Reading experience** and **Components** sections in the [[Manage sites#View site options|site options]]
+
+### Customize navigation
+
+Within Obsidian Publish, you have the ability to customize the navigation order and display of files and folders within the Publish [[File explorer]]. Navigation items are listed in published order by default. Notes not published will not appear within this pane.
+
+#### Accessing Customize navigation options
+
+1. In ribbon, to the left of the application window, select **Publish changes** (paper plane icon).
+2. In the **Publish changes** dialog, select **Change site options** (cog icon).
+3. Under **Components settings**, next to **Customize navigation**, select the **manage** button. 
+
+A new pop-up window titled **Navigation** will appear over your **Change site options** window.
+
+#### Adjust navigation items
+
+In the section labeled **Navigation preview**, you can adjust the display order of your published content.
+
+1. Select the folder or note you want to adjust.
+2. Drag the note or folder up or down until it is your desired place.
+3. In the lower right of the **Navigation** window, select **Done**. 
+
+Publish will send your navigation changes to your site. 
+
+
+#### Hide and unhide navigation items
+
+If there are notes or folders you have published, but you do not want visible within your Navigation, you can opt to hide those items instead. 
+
+1. Select the folder or note you want to adjust.
+2. Right click and select **Hide in navigation**. The item should now disappear from the **Navigation preview**.
+3. In the lower right of the **Navigation** window, select **Done**. 
+
+Publish will send your navigation changes to your site. 
+
+> [!tip] You can **Show hidden** files by selecting the checkbox to the right of the **Navigation Preview** title
+
+#### FAQ
+
+> [!question]- Q1. Can I move files from one folder to another within the **Navigation**?
+> No.
+> 
+> The file navigation structure for notes within folders needs to be maintained. You can adjust note order within folders (including the vault root), and folder order within other folders. 
+
+> [!question]- Q2. Can I edit the order of multiple notes and folders before selecting **Done**?
+> Yes!
+
+> [!question]- Q3. How do I revert these changes?
+> **Display order**: Select the **Restore Default** icon (counter clockwise rotate arrow) next to **Navigation item display order**. This will restore your navigation items to alphabetical order.
+>
+> **Hidden status**: Select the **Restore Default** icon (counter clockwise rotate arrow) next to **Hide pages or folders from navigation**. This will restore your hidden navigation items to a visible state.

--- a/en/Obsidian Publish/Manage sites.md
+++ b/en/Obsidian Publish/Manage sites.md
@@ -38,3 +38,55 @@ A site is a collection of notes that's hosted by Obsidian Publish and available 
 
 1. In ribbon, to the left of the application window, click **Publish changes** (paper plane icon).
 2. In the **Publish changes** dialog, click **Change site options** (cog icon).
+
+## Site Options
+
+### General
+
+| Option                          | Type   | Description                                                                                                                |
+|---------------------------------|--------|----------------------------------------------------------------------------------------------------------------------------|
+| Site Name                       | Input  | The public name and title of your Obsidian Publish site.                                                                   |
+| Homepage File                   | Input  | The location of the markdown file you want to act as your landing page.                                                    |
+| Logo                            | Input  | The image you want to act as your site banner. The image must [[Publish and unpublish notes#Publish notes\|be published]]. |
+| Site Collaboration              | Button | Declare other users you want to have access to edit your published notes. Users must have an Obsidian account.             |
+| Custom Domain                   | Button | [[Set up a custom domain]]                                                                                                 |
+| Disallow search engine indexing | Toggle | Prevents respectful search engines from crawling your site.                                                                |
+
+### Appearance
+
+| Option            | Type     | Description                                                                               |
+|-------------------|----------|-------------------------------------------------------------------------------------------|
+| Theme             | Dropdown | Choose how your theme presents on your site; **Light**, **Dark**, or **Adapt to System**. |
+| Light/Dark Toggle | Toggle   | Allow users to toggle **Light**/**Dark** mode with a toggle button on your site.          |
+
+## Reading experience
+
+| Option               | Type   | Description                                                                                |
+|----------------------|--------|--------------------------------------------------------------------------------------------|
+| Show hover preview   | Toggle | Enable or disable the ability of page preview when hovering over an active, internal link. |
+| Hide page title      | Toggle | Enable or disable the inline title of a published note to be displayed.                    |
+| Readable line length | Toggle | Enable or disable readable line length within your site.                                   |
+| Strict line breaks   | Toggle | Enable or disable single line breaks from being displayed on your site.                    |
+| Stack Pages          | Toggle | Enable or disable [[Use tabs in Obsidian#Stack tab groups\|Stacked tabs]] on your site.    |
+
+### Components
+
+| Option                 | Type   | Description                                                                                                                          |
+|------------------------|--------|--------------------------------------------------------------------------------------------------------------------------------------|
+| Show navigation        | Toggle | Enable or disable the [[File explorer]] view on your publish site.                                                                   |
+| Customize navigation   | Button | [[Customize your site#Customize navigation\|Customize]] the order of how your files are listed if **Show navigation** is toggled on. |
+| Show search bar        | Toggle | Enable or disable a search bar on your site.                                                                                         |
+| Show graph view        | Toggle | Enable or disable the graph view within the right sidebar of your site.                                                              |
+| Show table of contents | Toggle | Enable or disable the [[Outline\|Table of contents]] view on your site.                                                              |
+| Show backlinks         | Toggle | Enable or disable [[Backlinks]] on your site.                                                                                        |
+
+> [!tip] The search bar searches for published note titles, aliases, and headings.
+
+### Other site settings
+
+| Option                         | Type   | Description                                            |
+| ------------------------------ | ------ | ------------------------------------------------------ |
+| Passwords                      | Button | [[Obsidian Publish/Security and privacy#Add a site password\|Set a password]] to restrict access to your entire site. |
+| Google Analytics tracking code | Input  | **Custom Domain Url Only**. Place your Google Analytics site tracking code here.                                                       |
+
+> [!info] 

--- a/en/Obsidian Publish/Security and privacy.md
+++ b/en/Obsidian Publish/Security and privacy.md
@@ -4,7 +4,7 @@ Only the notes you choose to publish are sent to Obsidian's servers, and any not
 
 ## Add a site password
 
-**Caution:** If you add a site password, your site is no longer publicly available. Instead, readers see a password prompt when they access your site.
+**Caution:** If you add a site password, your site is no longer publicly available. Instead, readers see a password prompt when they access your site. Notes cannot be password protected individually.
 
 1. In ribbon, to the left of the application window, click **Publish changes** (paper plane icon).
 2. In the **Publish changes** dialog, click **Change site options** (cog icon).


### PR DESCRIPTION
This PR will round out some of the missing setting content on the Publish documents. It also adds a clarification to password protecting a site. Finally, it adds a how-to and FAQ on using the Customise navigation feature. 

This will close #531 

Signed-off-by: Sigrunixia <Scholarlysigrun@icloud.com>