### PR TITLE
Add callouts to custom domain.md

### DIFF
--- a/en/Obsidian Publish/Set up a custom domain.md
+++ b/en/Obsidian Publish/Set up a custom domain.md
@@ -1,11 +1,12 @@
 You can set up a custom domain or subdomain for your [[Introduction to Obsidian Publish|Obsidian Publish]] site.
 
-At the moment, we only support configuring custom domains using the following methods:
-
-- [[#Set up using CloudFlare]] using [Full mode](https://developers.cloudflare.com/ssl/origin-configuration/ssl-modes/full/).
-- [[#Set up using a proxy]]
-
-We don't yet have a way to provision SSL certificate on your behalf.
+> [!warning]
+> At the moment, we only support configuring custom domains using the following methods:
+>
+> - [[#Set up using CloudFlare]] using [Full mode](https://developers.cloudflare.com/ssl/origin-configuration/ssl-modes/full/).
+> - [[#Set up using a proxy]]
+> 
+> We don't yet have a way to provision SSL certificate on your behalf.
 
 ## Set up using CloudFlare
 
@@ -13,8 +14,8 @@ The easiest way to set up a custom domain or subdomain is to create a [CloudFlar
 
 The following steps use CloudFlare to configure a custom domain for your Obsidian Publish site, either using a root domain (`mysite.com`) or a subdomain (`notes.mysite.com`).
 
-> [!warning]
-> CloudFlare is the only officially supported provider for setting up custom domains. Using the following instructions with any other providers will likely not work.
+> [!important]
+> CloudFlare is the **only officially supported provider** for setting up custom domains. Using the following instructions with any other providers will likely not work.
 
 **CloudFlare:**
 


### PR DESCRIPTION
The content has been reformatted for increased visibility and readability.
- Now a warning callout highlights the methods we currently support for configuring a custom domain.
- Also, an warning callout was changed to an important callout later in the document