### PR TITLE
Add access control instructions for Sync/Publish

### DIFF
--- a/en/Obsidian Publish/Security and privacy.md
+++ b/en/Obsidian Publish/Security and privacy.md
@@ -1,3 +1,8 @@
+---
+aliases:
+  - Access control for Obsidian Publish
+  - Security/privacy for Obsidian Publish
+---
 You choose which notes you want to publish to [[Introduction to Obsidian Publish|Obsidian Publish]]. The rest of your notes stay safe in your vault.
 
 Only the notes you choose to publish are sent to Obsidian's servers, and any notes you unpublish are removed.
@@ -22,3 +27,14 @@ Only the notes you choose to publish are sent to Obsidian's servers, and any not
 2. In the **Publish changes** dialog, click **Change site options** (cog icon).
 3. Under **Other site settings**, next to **Passwords**, click **Manage**.
 5. Click the cross icon next to the password you want to delete.
+
+## Managing access to Obsidian Publish on your network
+
+To regulate access to Obsidian Publish on your network, you need to manage the following domains:
+
+- Frontend: `publish.obsidian.md`
+- Backend: `publish-main.obsidian.md`
+
+Additionally, the backend services employ the following subdomains: `publish-xx.obsidian.md`, where `xx` is a number ranging from `1 - 100`.
+
+> [!tip] If your firewall system supports it, we recommend whitelisting `publish-*.obsidian.md` to accommodate our continuous expansion of subdomains.

--- a/en/Obsidian Sync/Security and privacy.md
+++ b/en/Obsidian Sync/Security and privacy.md
@@ -1,3 +1,9 @@
+---
+aliases:
+  - Security/privacy for Obsidian Sync
+  - Access control for Obsidian Sync
+---
+
 For your safety, [[Introduction to Obsidian Sync|Obsidian Sync]] encrypts your [[Local and remote vaults|remote vault]] and all communication with Obsidian's servers. Before anyone can access your remote vault, they first need to decrypt it with an _encryption password_.
 
 When you create a new remote vault, you have two options:
@@ -44,3 +50,13 @@ To continue using Obsidian Sync, we suggest doing a full re-setup to be able to 
 ## Where do you host the servers for Obsidian Sync?
 
 We use DigitalOcean's data centers, which are located in the US.
+
+## Managing access to Obsidian Sync on your network
+
+To regulate access to Obsidian Sync on your network, you need to manage the following domains:
+
+`sync-xx.obsidian.md`
+
+The `xx` in this case represents a number ranging from `1 - 100`.
+
+> [!tip] If your firewall system supports it, we recommend whitelisting `sync-*.obsidian.md` to account for the continuous growth in subdomain numbers.

--- a/en/Obsidian Sync/Troubleshoot Obsidian Sync.md
+++ b/en/Obsidian Sync/Troubleshoot Obsidian Sync.md
@@ -13,7 +13,7 @@ When Sync downloads a new version of a file, and finds that there are conflicts 
 
 # Obsidian Sync deleted a note I just created on two devices
 
-Generally, Obsidian Sync tries to [[#Conflict resolution|resolve conflicts]] between devices by merging the content of the conflicting notes. Unfortunately, merging conflicting notes can cause issues for users who automatically generate notes on startup, for example using Daily notes.
+Generally, Obsidian Sync tries to [[#Conflict resolution|resolve conflicts]] between devices by merging the content of the conflicting notes. Unfortunately, merging conflicting notes can cause issues for users who automatically generate or alter notes on startup, for example using Daily notes.
 
 If a note was created locally on a device less than a couple of minutes before Sync downloads a remote version of that note, then Sync keeps the remote version without attempting to merge the two. You can still recover the local version using [[File recovery]].
 


### PR DESCRIPTION
Closes #569

Adds Access Control for domains for Obsidian Publish and Obsidian Sync in their respctive Security and Privacy notes.

Also added a minor clarification on troubleshooting, to indicate that alteration of notes on startup can also rewrite notes back to the remote vault.