### PR TITLE
Extends Daily Note organisation tip to explain folder structure and custom folders

### DIFF
--- a/en/Plugins/Daily notes.md
+++ b/en/Plugins/Daily notes.md
@@ -10,6 +10,8 @@ By default, Obsidian creates a new empty note named after today's date in the YY
 
 > [!tip]
 > If you prefer to have your daily notes in a separate folder, you can set the **New file location** under plugin options to change where Obsidian creates new daily notes.
+> For example you can use the format **[Journal]/YYYY/MMMM/YYYY-MMM-DD** to sort your journal notes by year and month in a custom folder called Journal.
+> To learn more about date formatting check out [momentJS-formatting](https://momentjs.com/docs/#/displaying/format/)
 
 ## Create a daily note from template
 

--- a/en/Plugins/Daily notes.md
+++ b/en/Plugins/Daily notes.md
@@ -8,10 +8,12 @@ To open today's daily note, either:
 
 By default, Obsidian creates a new empty note named after today's date in the YYYY-MM-DD format.
 
-> [!tip]
-> If you prefer to have your daily notes in a separate folder, you can set the **New file location** under plugin options to change where Obsidian creates new daily notes.
-> For example you can use the format **[Journal]/YYYY/MMMM/YYYY-MMM-DD** to sort your journal notes by year and month in a custom folder called Journal.
-> To learn more about date formatting check out [momentJS-formatting](https://momentjs.com/docs/#/displaying/format/)
+> [!tip] If you prefer to have your daily notes in a separate folder, you can set the <u>New file location</u> under plugin options to change where Obsidian creates new daily notes.
+
+> [!example]- Automated note sorting
+> You can automatically organize your daily notes into folders using the **New File Location** feature. For instance, if you set the file location as `Journal/YYYY/MMMM/YYYY-MMM-DD`, your notes will be created as `Journal/2023/January/2023-Jan-01`. 
+> 
+> You can explore more formatting options on the [momentJS](https://momentjs.com/docs/#/displaying/format/) documentation site.
 
 ## Create a daily note from template
 


### PR DESCRIPTION
This extends the tip of the Daily Notes formatting help to explain how to automatically create a folder structure for a journal.

Most users will want to use the Daily Notes as a journal. So they create many notes that need to be organized.

The tip now explains how to automatically include a folder structure and a link to more help about specific formating.

It also shows how to create files in a custom folder (which took me a lot of googling to find out)