### PR TITLE
Update the name of the former 'Tags' core plugin to 'Tags view'

### DIFF
--- a/en/Editing and formatting/Tags.md
+++ b/en/Editing and formatting/Tags.md
@@ -25,7 +25,7 @@ To find notes using the [[Search]] plugin, use the `tag` [[Search#Search operato
 
 You can also search for tags by clicking on them in your notes.
 
-To find notes using the [[Plugins/Tags|Tags]] plugin, select **Tags: Show tags** in the [[Command palette]], and then select the tag you want to search for.
+To find notes using the [[Tags view|Tags view]] plugin, select **Tags: Show tags** in the [[Command palette]], and then select the tag you want to search for.
 
 ## Nested tags
 
@@ -33,7 +33,7 @@ Nested tags define tag hierarchies that make it easier to find and filter relate
 
 Create nested tags by using forward slashes (`/`) in the tag name, for example  `#inbox/to-read` and `#inbox/processing`.
 
-Both the [[Search]] and [[Plugins/Tags|Tags]] plugins support nested tags.
+Both the [[Search]] and [[Tags view|Tags view]] plugins support nested tags.
 
 ## Tag format
 

--- a/en/Plugins/Core plugins.md
+++ b/en/Plugins/Core plugins.md
@@ -55,7 +55,7 @@ Some core plugins are disabled by default. You can enable them under **Settings 
 	- Create a presentation from your notes.
 - [[Introduction to Obsidian Sync|Sync]]
 	- Sync your notes across devices.
-- [[Plugins/Tags|Tags]]
+- [[Tags view|Tags view]]
 	- List all the tags in your vault.
 - [[Templates]]
 	- Insert pre-defined content into your notes.

--- a/en/Plugins/Tags view.md
+++ b/en/Plugins/Tags view.md
@@ -2,7 +2,7 @@
 aliases: [Tag pane]
 ---
 
-Tags lists all tags within your vault along with how many notes that contain them.
+Tags view lists all tags within your vault along with how many notes that contain them.
 
 Click a tag to search for it using [[Search]].
 

--- a/en/Plugins/Tags view.md
+++ b/en/Plugins/Tags view.md
@@ -1,5 +1,7 @@
 ---
-aliases: [Tag pane]
+aliases: 
+  - [Tag pane]
+  - Plugins/Tags
 ---
 
 Tags view lists all tags within your vault along with how many notes that contain them.


### PR DESCRIPTION
It seems that the former "Tags" core plugin has been renamed "Tags view":

<img width="1100" alt="image" src="https://github.com/obsidianmd/obsidian-help/assets/72342591/a8ed00a4-6830-46ae-b35c-730072fea674">

So I updated the help pages accordingly.