### PR TITLE
Fix typo in English markdown import documentation

### DIFF
--- a/en/Import notes/Import Markdown files.md
+++ b/en/Import notes/Import Markdown files.md
@@ -6,7 +6,7 @@ Obsidian uses Markdown `.md` files as the primary format for notes. This makes i
 There are several ways to add Markdown files to your Obsidian vault:
 
 1. Drag and drop files or folders into the [[File explorer]] window
-2. Use you system file browser (e.g. Windows Explorer or Finder on macOS), and move your files directly into the Obsidian vault folder.
+2. Use your system file browser (e.g. Windows Explorer or Finder on macOS), and move your files directly into the Obsidian vault folder.
 
 ### Converting from other flavors of Markdown
 


### PR DESCRIPTION
Change "you" to "your". Noticed this while trying to onboard to Obsidian.