### PR TITLE
Included languge pertaining to the right sidebar in the Obsidian app

### DIFF
--- a/en/Getting started/Glossary.md
+++ b/en/Getting started/Glossary.md
@@ -66,11 +66,12 @@ See also [[Pop-out windows]].
 ## Ribbon
 
 The **ribbon** functions as a container for frequently used action icons. In the desktop version, it's the vertical area situated on the far left. In the mobile version, it's represented by a menu button (![[lucide-menu.svg#icon]]) on the [[#status bar|status bar]].
+
 ## Sidebar
 
 An area that contains supporting [[#view|views]] organized as [[#tab|tabs]]. A sidebar can be split into multiple [[#tab group|tab groups]]. 
 
-Obsidian desktop has two sidebars, one on each side of the [[#main area]]. Obsidian's mobile interface features a single hidden sidebar on the left.
+Obsidian desktop has two sidebars, one on each side of the [[#main area]]. Both sidebars can be accessed by icons in the upper-left and upper-right corners in the Obsidian app, in addition to swiping left or right. The upper-right icon must be held to open the window.
 
 ## Snippet
 

--- a/en/Getting started/Use the mobile app.md
+++ b/en/Getting started/Use the mobile app.md
@@ -73,3 +73,7 @@ When you tap it, you’ll be able to switch to any open tab. You can also a new 
 ### Ribbon actions
 
 The mobile app has no [[Ribbon]]. Instead, the ribbon actions will be available when you tap **Open menu** (three bars icon), the last option on the navigation bar.
+
+### Right sidebar
+
+The right sidebar can be accessed by swiping left either while editing the active note or in the Reading view by holding the triple-dot icon in the upper-right corner.


### PR DESCRIPTION
Includes how to access the sidebars in the "Use the mobile app" note and an updated Glossary entry.