### PR TITLE
Early access versions: Fix typo; Publish limitations: Add search

### DIFF
--- a/en/Obsidian Publish/Publish limitations.md
+++ b/en/Obsidian Publish/Publish limitations.md
@@ -2,6 +2,11 @@
 aliases:
   - Publish Limitations
 ---
+
+## Search
+
+Publish only searches page names and headings. Full text search will be added in the [future](https://obsidian.md/roadmap).
+
 ## Community plugins
 
 Obsidian Publish has minimal support for [[Community plugins]]. 

--- a/en/Obsidian/Early access versions.md
+++ b/en/Obsidian/Early access versions.md
@@ -58,7 +58,7 @@ To switch back to using public versions (not early access) on desktop:
    - Linux: `~/.config/obsidian/obsidian-VERSION.asar`
 4. Restart Obsidian.
 
-## Switch back to public versions on desktop
+## Switch back to public versions on mobile
 
 To switch back to using public versions (not early access) on mobile:
 


### PR DESCRIPTION
The heading for reverting on mobile said "desktop" instead of "mobile".

Reported by Warrobot10 on the forum. https://forum.obsidian.md/t/typo-in-obsidian-help-site/76339?u=cawlinteffid

(There's apparently an extra commit because I accidentally did a pull request on my own version of the repo first. 😅)

The third commit fixes #647. (Sorry these are lumped together! I'll read the docs and hopefully have a less messy PR next time.)