### PR TITLE
Obsidian Sync and Misc updates

### DIFF
--- a/en/Attachments/icons/lucide-trash-2.svg
+++ b/en/Attachments/icons/lucide-trash-2.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-trash-2"><path d="M3 6h18m-2 0v14c0 1-1 2-2 2H7c-1 0-2-1-2-2V6m3 0V4c0-1 1-2 2-2h4c1 0 2 1 2 2v2"/><path d="M10 11L10 17"/><path d="M14 11L14 17"/></svg>

--- a/en/Attachments/icons/obsidian-icon-sync-circle.svg
+++ b/en/Attachments/icons/obsidian-icon-sync-circle.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round" class="svg-icon check-small"><path d="M12 21a9 9 0 0 0 9-9 9 9 0 0 0-9-9 9 9 0 0 0-9 9 9 9 0 0 0 9 9z"/><path d="M7.5 12.5l3 3L16 10"/></svg>

--- a/en/Contributing to Obsidian/Style guide.md
+++ b/en/Contributing to Obsidian/Style guide.md
@@ -261,3 +261,13 @@ Both images and icons should be optimized.
 > - **Linux/Unix** [Trimage](https://trimage.org)
 > 
 > We recommend an optimization rate of 65-75%.
+
+## Translations
+
+  Translate the entirety of the content when completing a translation. This includes and is not limited to:
+
+- Note names
+- Folder names
+- Aliases
+- Attachment names
+- Alt link text

--- a/en/Contributing to Obsidian/Translations.md
+++ b/en/Contributing to Obsidian/Translations.md
@@ -6,4 +6,4 @@ If you know another language, preferably natively, you can help translate the Ob
 
 To help translate the user interface, submit a pull request to the [translations repository](https://github.com/obsidianmd/obsidian-translations).
 
-To help improve our documentation, submit a pull request to the [obsidian-help](https://github.com/obsidianmd/obsidian-help) repository.
+To help improve our documentation, submit a pull request to the [obsidian-help](https://github.com/obsidianmd/obsidian-help) repository. Make sure to adhere to the translation [[Style guide#Translations|translations style guide]] when making changes.

--- a/en/Getting started/Glossary.md
+++ b/en/Getting started/Glossary.md
@@ -104,7 +104,15 @@ A **theme** changes the appearance of the Obsidian app using [CSS](https://devel
 
 ## Vault
 
+`Aliases: local vault, local data`
+
 A **vault** is a folder on your file system which contains [[#note|notes]] and an `.obsidian` folder with Obsidian-specific configuration. See also [[How Obsidian stores data]].
+
+### Remote vault
+
+`Aliases: Remote data`
+
+A [[Local and remote vaults|remote vault]] is a copy of your local vault that is maintained with [[Introduction to Obsidian Sync|Obsidian Sync]]. The remote vault data is updated based on changes to local data. 
 
 ## View
 

--- a/en/Getting started/Use the mobile app.md
+++ b/en/Getting started/Use the mobile app.md
@@ -66,8 +66,9 @@ The middle plus in circle icon lets you create a new note or switch to an existi
 
 ### Tab management
 
-The second icon to the right shows you how many tabs are currently open. The icon looks like a number in a box.
+The second icon to the right shows you how many tabs are currently open. The icon looks like a number in a box. For example, the icon below indicates there are two tabs open.
 
+<span class="mobile-navbar-tabs-action">2</span>
 When you tap it, you’ll be able to switch to any open tab. You can also open a new tab.
 
 ### Ribbon actions

--- a/en/Obsidian Sync/Introduction to Obsidian Sync.md
+++ b/en/Obsidian Sync/Introduction to Obsidian Sync.md
@@ -5,6 +5,7 @@ cssclasses:
   - list-cards
   - list-cards-mobile-full
 ---
+
 [Obsidian Sync](https://obsidian.md/sync) is an add-on service that allows you to store your notes on Obsidian's servers and sync them across your devices privately.
 
 ## How to use Obsidian Sync

--- a/en/Obsidian Sync/Local and remote vaults.md
+++ b/en/Obsidian Sync/Local and remote vaults.md
@@ -2,6 +2,8 @@
 aliases:
   - Local vaults
   - remote vaults
+  - remote vault
+  - local vault
 ---
 
 Obsidian stores your notes in a _local_ vault on your computer or device. If you want to access your notes from other devices, you need to share your local vault with those devices.

--- a/en/Obsidian Sync/Local and remote vaults.md
+++ b/en/Obsidian Sync/Local and remote vaults.md
@@ -4,7 +4,7 @@ aliases:
   - remote vaults
 ---
 
-Obsidian stores your notes in a _local_ vault on your computer. If you want to access your notes from other devices, you need to share your local vault with those devices.
+Obsidian stores your notes in a _local_ vault on your computer or device. If you want to access your notes from other devices, you need to share your local vault with those devices.
 
 [[Introduction to Obsidian Sync|Obsidian Sync]] makes this easier by letting you sync your local vault with a _remote_ vault that lives on Obsidian's servers.
 

--- a/en/Obsidian Sync/Security and privacy.md
+++ b/en/Obsidian Sync/Security and privacy.md
@@ -48,7 +48,7 @@ To continue using Obsidian Sync, we suggest doing a full re-setup to be able to 
 
 1. Make a full vault backup on your primary device, just in case something goes wrong. This can be as simple as making a copy of the vault folder, or creating a zip file from the vault.
 2. Disconnect the remote vault in each of your devices. This can be done by going to **Settings → Sync → Pick remote vault → Disconnect**.
-3. Create a new remote vault on your primary device from the same Settings page. Optionally, you can delete the previous remote vault since you don't have the password for it anyway. (You may have to delete the previous remote vault if you are at the vault limit)
+3. [[Set up Obsidian Sync#Create a new remote vault|Create a new remote vault]] on your primary device from the same Settings page. Optionally, you can delete the previous remote vault since you don't have the password for it anyway. (You may have to delete the previous remote vault if you are at the [[Sync limitations#How many remote vaults can I have?|vault limit]])
 4. Wait for your primary device to sync. Watch the sync indicator at the bottom right of the screen until it displays a green checkmark.
 5. Connect each of your device to the same newly created remote vault. When connecting, you will be shown a warning about vault merging, this is expected and you can proceed. Wait for each device to fully sync before moving onto the next. This reduces the chances of issues.
 6. Now all your devices should be connected to the new remote vault.
@@ -58,7 +58,7 @@ To continue using Obsidian Sync, we suggest doing a full re-setup to be able to 
 
 Our data centers, powered by [DigitalOcean](https://www.digitalocean.com), provide geo-regional remote vault hosting options in the following locations:
 
-> [!info] Sync geo-regions
+> [!abstract] Sync geo-regions
 > **Automatic**: Your data center is chosen based off your IP location.
 > 
 > **Asia**: Singapore

--- a/en/Obsidian Sync/Select files and settings to sync.md
+++ b/en/Obsidian Sync/Select files and settings to sync.md
@@ -69,3 +69,5 @@ To set your settings folder:
 1. Open **Settings → General**.
 2. In **Override config folder**, type the name of your profile, starting with a period (`.`). For example, `.obsidian-mobile`.
 3. Relaunch Obsidian to have the changes take effect. 
+
+> [!note] Changing your settings profile will require you to [[#Initially adjusting your Sync settings|adjust your sync settings]] again. 

--- a/en/Obsidian Sync/Select files and settings to sync.md
+++ b/en/Obsidian Sync/Select files and settings to sync.md
@@ -16,58 +16,55 @@ This allows users to configure Sync differently on each device according to thei
 > 
 > For example, if you change the path of your daily notes in the [[Daily Notes]] plugin, you need to restart Obsidian on your other devices to use the new path.
 
-## Initially adjusting your Sync settings
-
-
-> [!help] This set of instructions is intended for users who wish to modify their [[Set up Obsidian Sync on another device|sync settings on an additional device]] or a new vault after [[Set up Obsidian Sync#Connect to a remote vault|establishing a connection to a remote vault]].
-
-1. If you haven't already, close (x) or dismiss the pop-up window prompting you to **Exclude Folders** and **Start Syncing**.
-2. On your primary device, navigate to **Settings** → **Sync**.
-3. Under **Vault configuration sync**, activate the settings you want to synchronize.
-    1. If you make changes to any settings, restart Obsidian completely.
-4. After restarting Obsidian, if any settings were modified, return to **Settings** → **Sync**.
-5. Choose **Resume**.
-6. The synchronization process will initiate, involving uploading, downloading, or merging your files, depending on whether the remote vault contains existing files or not.
-
-
 ## Syncing your vault settings
 
 > [!help] These instructions are designed for users with existing multi-device sync setups who wish to modify these settings across their devices.
 
 **Primary device**
+
+The primary device is your source-of-truth device. It can also mean the device you make the new change on, that you wish to sync across your other devices.
+
 1. Access **Settings** → **Sync**.
 2. Activate the desired settings under **Vault configuration sync**.
-3. Restart Obsidian
+3. Restart Obsidian. On mobile or tablet, this may require a force quit.
 4. Allow time for the settings to synchronize with your remote vault.
 
 **Secondary device(s)**
+
+The secondary device is your other devices. It can also mean the devices you wish to receive an updated change on.
+
 1. Navigate to **Settings** → **Sync**.
 2. Enable the desired settings under **Vault configuration sync**.
 3. Wait for the changes to be downloaded from your remote vault.
-4. Restart the application to ensure that your synchronized settings take effect.
+4. Restart the application to ensure that your synchronized settings take effect. On mobile or tablet, this may require a force quit.
 
 ## Select file types to sync
 
 1. Open **Settings → Sync**.
 2. Under **Selective sync**, enable the file types you want to sync.
+3. Restart the application to ensure that your new settings take effect. On mobile or tablet, this may require a force quit.
 
 ## Exclude folder from being synced
 
 By default, Obsidian syncs all files and folders in your vault. If you don't want Obsidian to sync a certain folder, you can exclude it.
 
 1. Open **Settings → Sync**.
-2. Under **Selective sync**, next to **Excluded folders**, click **Manage**.
-3. Click the checkbox to the left of folder you want to exclude.
-4. Click **Done**.
+2. Under **Selective sync**, next to **Excluded folders**, select **Manage**.
+3. Select the checkbox to the left of the folder you want to exclude.
+4. Select **Done**.
 
+## Settings profiles
+
+Obsidian Sync can sync multiple [[Configuration folder|configuration folders]] to the same remote vault. You can use this to create different profiles, for example, one for mobile devices and another for your laptop.
 ## Create a settings profile
-
-Obsidian Sync can sync multiple [[Configuration folder|configuration folders]] to the same remote vault. You can use this to create different profiles, for example one for mobile devices and another for your laptop.
 
 To set your settings folder:
 
 1. Open **Settings → General**.
 2. In **Override config folder**, type the name of your profile, starting with a period (`.`). For example, `.obsidian-mobile`.
-3. Relaunch Obsidian to have the changes take effect. 
+3. Relaunch Obsidian to have the changes take effect.
 
-> [!note] Changing your settings profile will require you to [[#Initially adjusting your Sync settings|adjust your sync settings]] again. 
+> [!note] 
+> Changing your settings profile will require you to adjust your sync settings again. You will also need to redownload plugins and themes.
+> 
+> You can prevent this by making a copy of your `.obsidian` folder, and renaming it to your new config folder name (`.obsidian-mobile`) before making the changes.

--- a/en/Obsidian Sync/Set up Obsidian Sync on another device.md
+++ b/en/Obsidian Sync/Set up Obsidian Sync on another device.md
@@ -1,5 +1,8 @@
 ---
-aliases: Add another device
+aliases:
+  - Add another device
+cssclasses:
+  - soft-embed
 ---
 
 In this guide, you'll create a local vault on another device to sync with your remote vault. This keeps the local vaults on all your devices in sync.
@@ -24,7 +27,8 @@ If this is the first time you open Obsidian on the device, follow these steps:
 7. Enter a local name for the vault, or leave to use the same name as the remote vault.
 8. Select **Browse** and select the folder on your device where you want to sync the vault.
 9. Select **Create**.
-10. Select **Start syncing** to sync your local vault with the remote vault.
+
+You will be presented with the option to **Start Syncing**. If you continue at this stage, Obsidian Sync will use the default sync settings to load files to your device. 
 
 ## Sync an existing local vault
 
@@ -36,14 +40,16 @@ This section explains how to sync an existing local vault with a remote vault.
 
 ### Connect to a remote vault
 
-1. Open **Settings**.
-2. In the sidebar, select **Sync**.
-3. Next to **Pick remote vault**, click **Choose**.
-4. Click **Connect** next to the remote vault you want to connect to. If the vault on your device already contains some notes (not recommended), you'll be warned that those notes will be merged before proceeding.
-5. In **Encryption password**, enter the password for your vault, if you have one.
+1. Open **Settings**.
+2. In the sidebar, select **Sync**.
+3. Next to **Pick remote vault**, click **Choose**.
+4. Click **Connect** next to the remote vault you want to connect to. If the vault on your device already contains some notes (not recommended), you'll be warned that those notes will be merged before proceeding.
+5. In **Encryption password**, enter the password for your vault, if you have one.
 
 ## Next steps
 
-Obsidian Sync displays a green checkmark in the bottom-right corner when it has finished syncing the vaults.
+If you don't want to sync the entire vault to your device, refer to [[Set up Obsidian Sync#Adjust Obsidian Sync settings|Adjust Obsidian Sync settings]] and [[Select files and settings to sync]].
 
-If you don't want to sync the entire vault to your device, refer to [[Select files and settings to sync]].
+If you do want to sync the entire vault to the device, you may begin Syncing. 
+
+![[Set up Obsidian Sync#^obsidian-sync-status]]

--- a/en/Obsidian Sync/Set up Obsidian Sync.md
+++ b/en/Obsidian Sync/Set up Obsidian Sync.md
@@ -1,3 +1,9 @@
+---
+cssclasses:
+  - soft-embed
+---
+
+
 In this guide, you'll enable [[Introduction to Obsidian Sync|Obsidian Sync]] for your vault.
 
 > [!hint] Remote vaults and local vaults
@@ -7,6 +13,9 @@ In this guide, you'll enable [[Introduction to Obsidian Sync|Obsidian Sync]] for
 
 - An Obsidian account. If you don't have one, [sign up now](https://obsidian.md/account#mode=signup).
 - An active Obsidian Sync subscription. If you don't have one, subscribe from your [account page](https://obsidian.md/account).
+- Sync enabled within the [[Core plugins]] settings. 
+
+> [!danger] Is your current vault in an iCloud, OneDrive, Dropbox, or other syncing folder? Please [[Back up your vault|read this guide]] before proceeding.
 
 ## Log in with your Obsidian account
 
@@ -27,39 +36,88 @@ In this guide, you'll enable [[Introduction to Obsidian Sync|Obsidian Sync]] for
 1. Open **Settings**.
 2. In the sidebar, select **Sync**.
 3. Next to **Remote vault**, select **Choose**.
-4. Click **Create new vault**.
+4. Select **Create new vault**.
 5. In **Vault name**, enter the name of the remote vault.
 6. In **Region**, choose your server [[#Regional sync servers|region]] for your remote vault. 
 7. In **Encryption password**, choose a password for your vault. This creates an end-to-end encrypted vault. The vault password is separate from your Obsidian account and can be different for each of your vaults. For more information, refer to [[Security and privacy]].
-8. Click **Create**.
-
-### Regional sync servers
-
-As of [Obsidian release 1.5](https://obsidian.md/changelog/2023-11-20-desktop-v1.5.0/), users can now choose the hosting location for their remote vault. 
-
-For users not yet on release 1.5 or a later version, the assignment of their remote vault location will be handled automatically. 
-
-![[sync-regional-sync-servers.png#interface|300]]
-
-After selecting a location, it's crucial to be aware that the data center **cannot** be changed afterward. If you wish to relocate your data, the process involves [[#Create a new remote vault|creating a new remote vault]] and specifying the desired hosting location during the setup.
-
-![[Obsidian Sync/Security and privacy#^sync-geo-regions]]
+8. Select **Create**.
 
 ## Connect to a remote vault
 
-> [!danger] Is your current vault in an iCloud, OneDrive, Dropbox, or other syncing folder? Please [[Back up your vault|read this guide]] before proceeding.
-
-
-1. Next to your newly created vault, select **Connect**.
-2. In **Encryption password**, enter the password you configured for the vault if you opted into [[Obsidian Sync/Security and privacy#What does end-to-end encryption mean?|end-to-end encryption]].
+1. Select **Connect** next to your newly created vault.
+2. Enter the password you configured for the vault in the **Encryption password** field if you opted into [[Obsidian Sync/Security and privacy#What does end-to-end encryption mean?|end-to-end encryption]].
 3. Select **Unlock vault**.
-4. It is highly recommended that you <u>do not</u> start syncing yet. Instead, proceed to [[Select files and settings to sync#Initially adjusting your Sync settings|syncing your vault settings for the first time]].
-	1. If you wish to start syncing right away, select **Start Syncing**.
+4. **Do not start syncing yet.** Check your sync settings in [[#Adjust Obsidian Sync settings|adjust Obsidian Sync settings]].
+    - If you wish to start syncing immediately, move onto [[#Begin syncing with Obsidian Sync|begin syncing with Obsidian Sync]].
+5. If you haven't already, close or dismiss the pop-up window prompting you to **Exclude Folders** and **Start Syncing**. Proceed to the next step.
 
+#### Adjust Obsidian Sync settings
+
+1. Navigate to **Settings** → **Sync** if needed.
+2. Toggle the settings under **Selective Sync** and **Vault configuration sync** to indicate which items should be synced to and from the remote vault.
+    - **Note**: If you recently disconnected from a remote vault and are reconnecting without an application restart, some settings may already be toggled on.
+3. If you make changes to any settings, restart Obsidian completely.
+4. Once Obsidian is restarted, return to **Settings** → **Sync**.
+
+> [!tip] Add a device name to make reading your Sync logs easier!
 
 > [!note] Sync settings and other file types
 > By default, Sync only syncs notes and images. For information how to sync other file types, refer to [[Select files and settings to sync#Select file types to sync|Select file types to sync]].
 >
 > If you want to sync vault configuration, such as settings for [[Core plugins]], [[Hotkeys]], or [[Community plugins]], learn how to [[Select files and settings to sync#Sync vault configuration|Sync vault configuration]].
 
+#### Begin syncing with Obsidian Sync
 
+If you are beginning syncing after connecting to a remote vault, you will see a **Start Syncing** button. Select this button to begin syncing.
+
+If you are beginning syncing after adjusting Obsidian Sync's settings and restarting the application, you will see a **Resume** button within Sync's settings. Select this button to begin syncing.
+
+> [!done] Syncing status
+> Obsidian Sync displays a green circle with a checkmark ( ![[obsidian-icon-sync-circle.svg#icon]] ) in the bottom-right corner when it has finished syncing the vaults. On tablets, this icon is found in the right sidebar. 
+>
+> Smaller mobile devices currently do not show the Obsidian Sync status icon.
+^obsidian-sync-status
+
+> [!todo] Next steps
+> To connect other devices to your newly created and synced remote vault, move onto [[Set up Obsidian Sync on another device]].
+>
+> To learn more about settings and files, move onto [[Select files and settings to sync]].
+
+## Disconnect from a remote vault
+
+1. Open Obsidian's **Settings**.
+2. Select **Sync** in the sidebar.
+3. Click the **Disconnect** button next to Remote vaults.
+
+You are now disconnected from the remote vault and are no longer syncing on this device.
+
+## Delete a remote vault
+
+> [!tip] Deleting a remote vault will not delete your local data on your device.
+
+1. Open **Settings**.
+2. In the sidebar, select **Sync**.
+3. Select **Manage** next to Remote vaults. A window will open with your list of remote vaults.
+4. Select the trash can icon ( ![[lucide-trash-2.svg#icon]] ) next to the remote vault you want to delete.
+5. Confirm the deletion by selecting the red **Delete** button.
+6. Your remote vault has been deleted.
+
+## Regional sync servers
+
+As of [Obsidian release 1.5](https://obsidian.md/changelog/2023-11-20-desktop-v1.5.0/), users can now choose the hosting location for their remote vault. For users not yet on release 1.5 or a later version, the assignment of their remote vault location will be handled automatically.
+
+![[sync-regional-sync-servers.png#interface|300]]
+
+After selecting a location, it's crucial to be aware that the data center **cannot** be changed afterward. If you wish to relocate your data, the process involves recreating a remote vault and specifying the desired hosting location during the setup.
+
+![[Obsidian Sync/Security and privacy#^sync-geo-regions]]
+
+### Change your remote vault region
+
+To change your remote vault's region, you will need to perform the following steps in order.
+
+![[#Disconnect from a remote vault]]
+![[#Create a new remote vault]]
+![[#Connect to a remote vault]]
+
+Additionally, you can [[#Delete a remote vault|delete your old remote vault]] once you have confirmed transition to your new remote vault and its region. 

--- a/en/Obsidian Sync/Sync limitations.md
+++ b/en/Obsidian Sync/Sync limitations.md
@@ -4,6 +4,7 @@ aliases:
   - Sync limitations
   - Sync FAQ
 ---
+
 This page lists some of the common questions related to questions and limitations for [[Introduction to Obsidian Sync|Obsidian Sync]].
 
 ## General
@@ -14,7 +15,9 @@ Obsidian Sync supports every platform that Obsidian can run on. Currently that m
 
 ### How much storage do I have?
 
-The storage limit depends on which Obsidian Sync plan you are subscribed to. The maximum storage amount is 100 GB. This storage limit includes [[Version history|version history]]. You can view **Storage usage** in the Obsidian app by going to **Settings → Sync**.
+The storage limit depends on which Obsidian Sync plan you are subscribed to. The maximum storage amount is 100 GB. This storage limit includes [[Version history|version history]]. 
+
+You can view **Storage usage** in the Obsidian app by going to **Settings → Sync**.
 
 ### How many remote vaults can I have?
 

--- a/en/Obsidian Sync/Sync limitations.md
+++ b/en/Obsidian Sync/Sync limitations.md
@@ -13,6 +13,10 @@ This page lists some of the common questions related to questions and limitation
 
 Obsidian Sync supports every platform that Obsidian can run on. Currently that means Windows, macOS, Linux, Android and iOS.
 
+#### Does Obsidian work with Apple's Lockdown Mode?
+
+Obsidian will work with [Lockdown Mode](https://support.apple.com/en-us/105120) so long as Obsidian is added as an exclusion. Some individual users with edge cases experience problems using Obsidian with lockdown mode. 
+
 ### How much storage do I have?
 
 The storage limit depends on which Obsidian Sync plan you are subscribed to. The maximum storage amount is 100 GB. This storage limit includes [[Version history|version history]]. 
@@ -41,6 +45,10 @@ You can add additional syncing options of PDF's, audio files, video files, and o
 
 No, files are only synced when Obsidian is running.
 
+### Does Obsidian Sync live-reload my settings?
+
+No, plugins, settings, and theme updates from one device, will require a restart of the application on the other devices once the update is received. 
+
 ### What's the maximum number of people I can share a remote vault with?
 
 You can [[Collaborate on a shared vault|share a remote vault]] with up to 10 people.
@@ -51,13 +59,15 @@ These are commonly asked questions on Obsidian's data retention. For more in dep
 
 ### How long do you keep the version history?
 
-Older [[Version history|versions]] of Markdown files are stored for one year, and then deleted. Older versions of attachments are stored for two weeks.
+Older [[Version history|versions]] of Markdown files are stored for one year, and then deleted. 
+
+Older versions of [[Attachments|attachments]] are stored for two weeks.
 
 ### How long do you keep my data after my subscription expires?
 
 We keep data in your remote vaults, including version history, for one month after your subscription expires. Any local vaults on your devices are unaffected.
 
-As long as you renew within one month, there should be no impact on your usage. If you renew after a month, when your remote vaults have been removed, you can [[Set up Obsidian Sync|create a new remote vault re-connect your local vault]].
+As long as you renew within one month, there should be no impact on your usage. If you renew after a month, when your remote vaults have been removed, you can [[Set up Obsidian Sync|create a new remote vault]] and connect your local vault.
 
 ### Do you keep my data if I refund my subscription service?
 

--- a/en/Obsidian Sync/Troubleshoot Obsidian Sync.md
+++ b/en/Obsidian Sync/Troubleshoot Obsidian Sync.md
@@ -18,6 +18,17 @@ Generally, Obsidian Sync tries to [[#Conflict resolution|resolve conflicts]] bet
 
 If a note was created locally on a device less than a couple of minutes before Sync downloads a remote version of that note, then Sync keeps the remote version without attempting to merge the two. You can still recover the local version using [[File recovery]].
 
+## Obsidian Sync will not Sync my plugins and settings updates
+
+Obsidian [[Sync limitations#Does Obsidian Sync live-reload my settings?|does not live]], or hot reload, settings. You will need to restart Obsidian on the other devices after they have updated their settings. On mobile devices, this may require a force-quit of Obsidian.
+
+> [!example]- Example: Changing a theme
+> - Your primary device, a computer, currently has a custom theme and you decide to change it back to the default theme.
+> - You confirm in the Sync log that the files have been sent to the remote vault. However, your open mobile device, still reflects your custom theme.
+> - You open the Sync log on the mobile device, and confirm that you have received an updated `appearance.json`.
+> - You restart Obsidian on the mobile device.
+> - Once re-opened, the mobile device should reflect the same theme as your primary device. 
+
 ## What does "Vault limit exceeded" mean?
 
 Your account exceeds the [[Sync limitations#How large can each remote vault be|maximum size of 50 GB]]. See [[Storage limits]].
@@ -39,4 +50,4 @@ This error may occur in the following scenarios:
 2. The sync subscription was inactive for over 30 days, leading to the removal of the remote vault.
 3. The subscription was canceled or refunded, resulting in the purging of the remote vault.
 
-In each case, it is necessary to disconnect from the remote vault and establish a new connection, ensuring the data on your device is retained.
+In each case, it is necessary to [[Set up Obsidian Sync#Disconnect to a remote vault|disconnect from the remote vault]] and [[Set up Obsidian Sync#Create a new remote vault|create a new remote vault]], ensuring the data on your device is retained.

--- a/en/Obsidian Sync/Troubleshoot Obsidian Sync.md
+++ b/en/Obsidian Sync/Troubleshoot Obsidian Sync.md
@@ -4,11 +4,13 @@ This page lists common issues that you might encounter, and how to address them.
 
 ## Conflict resolution
 
-A conflict happens when you make changes to the same file on two or more devices between syncs. For example, you might have changed a file on your computer, and before that change is uploaded, you also change the same file on your phone.
+A conflict happens when you make changes to the same note on two or more devices between syncs. For example, you might have changed a note on your computer, and before that change is uploaded, you also change the same note on your phone.
 
 Conflicts usually happen more frequently if you work offline, since there are more changes and a longer period of time between syncs and thus more potential conflicts.
 
-When Sync downloads a new version of a file, and finds that there are conflicts with the local version, the changes are merged with Google's [diff-match-patch](https://github.com/google/diff-match-patch) algorithm.
+When Sync downloads a new version of a note, and finds that there are conflicts with the local version, the changes are merged with Google's [diff-match-patch](https://github.com/google/diff-match-patch) algorithm.
+
+For conflicts in Obsidian settings, such as plugin settings, the process is a different. Obsidian Sync will merge the JSON files, by loading the local JSON and the remote JSON. Then Sync will apply the keys from the local JSON on top of the remote JSON.
 
 > [!help] To find when conflicts have happened, you can search for "Merging conflicted file" in **Settings → Sync → Sync activity → View**.
 

--- a/en/User interface/Sidebar.md
+++ b/en/User interface/Sidebar.md
@@ -2,9 +2,9 @@
 aliases:
   - User interface/Workspace/Sidebar
 ---
-On desktop Obsidian has two sidebars on both left and right. The left sidebar includes the [[Ribbon]].
+On desktop and larger tablets, Obsidian has two sidebars on both left and right. The left sidebar includes the [[Ribbon]].
 
-On mobile, Obsidian sidebars are [[#Open hidden sidebars|collapsed by default]]. They can be opened by using left and right swipe gestures from the edge of the screen.
+On mobile and smaller tablets, Obsidian sidebars are [[#Open hidden sidebars|collapsed by default]]. They can be opened by using left and right swipe gestures from the edge of the screen.
 
 ## Open hidden sidebars
 

--- a/en/publish.css
+++ b/en/publish.css
@@ -238,13 +238,20 @@ display: none;
     position: relative;
 }
 
+.soft-embed .markdown-embed h2 {
+font-size: var(--h3-size);
+}
+
+.soft-embed .markdown-embed h3 {
+    font-size: var(--h4-size);
+}
+
 .soft-embed .markdown-embed .markdown-embed-content {
     max-height: unset;
     overflow: unset;
 }
 
 .soft-embed .markdown-embed .markdown-embed-content     > .markdown-preview-view  {
-// no scroll
 overflow-y: unset;
 }
 

--- a/en/publish.css
+++ b/en/publish.css
@@ -7,6 +7,7 @@ img {
     border-radius: 4px;
 }
 
+/* Makes icons invert in dark mode */
 .theme-dark img[src*="lucide"],
 .theme-dark img[src*="obsidian-icon"] {
     filter: invert(1);
@@ -29,6 +30,7 @@ img[src$="#outline"] {
     border: 1px solid var(--background-modifier-border);
 }
 
+/* Adds proper alignment to icons */
 span[src$="#icon"] img,
 img[src$="#icon"] {
     vertical-align: text-bottom;
@@ -62,6 +64,7 @@ img[src$="#icon"] {
     display: none;
 }
 
+/* Hides page headers in Publish, use H1 if needed */
 .hide-title .page-header {
     display: none;
 }
@@ -79,6 +82,7 @@ img[src$="#icon"] {
     border: none;
 }
 
+/* Kepano's List Cards */
 .list-cards {
 	--list-cards-template: repeat(2, minmax(0, 1fr));
 }
@@ -214,6 +218,57 @@ img[src$="#icon"] {
     filter: invert(1);
 }
 
+/* Soft Embeds*/
+
+.soft-embed body {
+    --embed-border-left: none;
+    --embed-border-right: none;
+    --embed-padding: var(--size-2-1) var(--size-4-2);
+}
+
+.soft-embed .markdown-embed-link,
+.soft-embed .file-embed-link {
+display: none;
+}
+
+.soft-embed .markdown-embed {
+    border-right: none;
+    border-left: none;
+    border-radius: var(--radius-l);
+    position: relative;
+}
+
+.soft-embed .markdown-embed .markdown-embed-content {
+    max-height: unset;
+    overflow: unset;
+}
+
+.soft-embed .markdown-embed .markdown-embed-content     > .markdown-preview-view  {
+// no scroll
+overflow-y: unset;
+}
+
+.soft-embed .markdown-embed .markdown-rendered blockquote {
+    border-left: none;
+    padding: 0;
+}
+
+/* Add CSS created Icons from Obsidian */
+
+/* Mobile Tab Switcher*/
+.mobile-navbar-tabs-action {
+    align-items: center;
+    border-radius: var(--clickable-icon-radius);
+    border: 2px solid var(--icon-color);
+    display: flex;
+    font-size: calc(var(--icon-size) * 0.6);
+    font-weight: var(--bold-weight);
+    justify-content: center;
+    height: 20px;
+    width: var(--icon-size);
+}
+
+/* Mobile adjustments */
 @media screen and (max-width: 750px) {
     .site-header-text {
         display: none;


### PR DESCRIPTION
Adjusts documentation for Obsidian Sync to make it more readable and condensed.

Added more imperative casing on existing instructions. 

Adjusted CSS to account for a need to soften embeds in some pages.

Adjusted CSS to show CSS-only icon in help docs. 