### PR TITLE
Fix: Japanese help site does not display Japanese correctly

### DIFF
--- a/ja/publish.css
+++ b/ja/publish.css
@@ -1,0 +1,4 @@
+body {
+  /* Font */
+  --font-default: ui-sans-serif, -apple-system, BlinkMacSystemFont, Roboto, "Helvetica", "Arial", "Segoe UI", "Inter", "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", sans-serif;
+}

--- a/publish.css
+++ b/publish.css
@@ -1,4 +1,0 @@
-body {
-  /* Font */
-  --font-default: ui-sans-serif, -apple-system, BlinkMacSystemFont, Roboto, "Helvetica", "Arial", "Segoe UI", "Inter", "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", sans-serif;
-}

--- a/publish.css
+++ b/publish.css
@@ -1,0 +1,4 @@
+body {
+  /* Font */
+  --font-default: ui-sans-serif, -apple-system, BlinkMacSystemFont, Roboto, "Helvetica", "Arial", "Segoe UI", "Inter", "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", sans-serif;
+}


### PR DESCRIPTION
When using Windows, the Japanese text on the Japanese help site is not displayed correctly. It is frustrating to read.

The cause is that Microsoft YaHei font is specified as a font in Obsidian Publish. This font is for Chinese and does not support Japanese.

This bug has been posted on Obsidian's Forum, but it has not been fixed for almost a year.
https://forum.obsidian.md/t/incorrect-font-for-japanese-on-windows-and-publish/59629

So I would like to make a quick fix about the help site.

This fix is intended to remove the Microsoft YaHei setting from the text.
( There is a font issue with Graph View as well, but that will not be fixed this time. )

I am not sure if putting publish.css in this location will work. Please point out any mistakes.

----

Current: 
![image](https://github.com/obsidianmd/obsidian-help/assets/6022981/f4a47378-9ab6-4c6d-87db-a47797d31c62)

Expected:
![image](https://github.com/obsidianmd/obsidian-help/assets/6022981/665b593c-3113-48d7-a45f-55cab49a9a4a)
( The font specified as sans-serif in the browser is used. )
