### PR TITLE
Page preview clarification

### DIFF
--- a/en/Plugins/Page preview.md
+++ b/en/Plugins/Page preview.md
@@ -4,5 +4,5 @@ By default, hovering over a link will preview that file in [[File explorer]], [[
 
 There is also an option to require `Ctrl` (or `Cmd` on macOS) while hovering to see the file. The settings for this option are under Core plugins > Page preview.
 
-> [!warning]
+> [!hint]
 > Preview is **on by default**. Toggling the plugin option will **turn the behavior off**.

--- a/en/Plugins/Page preview.md
+++ b/en/Plugins/Page preview.md
@@ -1,8 +1,8 @@
 Page preview lets you preview a page when you hover the cursor over an internal link, without needing to navigate to that page.
 
-In addition to editor, you can preview notes in several other parts of Obsidian, such as [[File explorer]], [[Search]], and [[Backlinks]].
+By default, hovering over a link will preview that file in [[File explorer]], [[Search]], [[Backlinks]], and more. To preview a page while in Editing view, press `Ctrl` (or `Cmd` on macOS) while hovering the cursor over the link.
 
-To preview a page while in Editing view, press `Ctrl` (or `Cmd` on macOS) while hovering the cursor over the link.
+There is also an option to require `Ctrl` (or `Cmd` on macOS) while hovering to see the file. The settings for this option are under Core plugins > Page preview.
 
-> [!tip]
-> In the plugin settings, you can configure Page preview to only open the preview automatically, or only when you press `Ctrl` (or `Cmd` on macOS).
+> [!warning]
+> Preview is **on by default**. Toggling the plugin option will **turn the behavior off**.


### PR DESCRIPTION
Behavior is counterintuitive by default and would be helpful to explain that it's on by default.