### PR TITLE
Update installation instructions for Chromebooks

### DIFF
--- a/en/Getting started/Download and install Obsidian.md
+++ b/en/Getting started/Download and install Obsidian.md
@@ -43,6 +43,7 @@ If you use Linux, you can install Obsidian in several ways. Follow the instructi
    chmod u+x Obsidian-<version>.AppImage
    ./Obsidian-<version>.AppImage
    ```
+Note: On Chromebooks, the `libnss3-dev` package must be installed or you may receive the error `error while loading shared libraries: libnss3.so: cannot open shared object file: No such file or directory`.
 
 ### Install Obsidian using Flatpak
 


### PR DESCRIPTION
On Chromebooks, the linux installation (Debian bullseye) does not include the `libnss3.so` shared library, which results in the following error when trying to launch the AppImage version of Obsidian:
```
error while loading shared libraries: libnss3.so: cannot open shared object file: No such file or directory
```
Installing the `libnss3-dev` package (`sudo apt install libnss3-dev`) resolves this.

This has been an issue for almost 4 years at this point (see [forum post](https://forum.obsidian.md/t/linux-appimage-install-instructions-incomplete-missing-libnss3-so/3817)), so it should be documented IMO.

I'm not sure the formatting/style of the note is the best, so feel free to change it.