### PR TITLE
Improve "sync isn't backup" link text

### DIFF
--- a/en/Getting started/Back up your Obsidian files.md
+++ b/en/Getting started/Back up your Obsidian files.md
@@ -13,7 +13,7 @@ Your notes are stored locally on your device by default, not in the cloud. This 
 
 ## Syncing is not a backup
 
-Services like [[Introduction to Obsidian Sync|Obsidian Sync]], iCloud, OneDrive, and Dropbox sync your notes across devices. They may offer [[Version history|note restoration]], but they are **not** designed to [back up your vault](https://www.backblaze.com/blog/cloud-backup-vs-cloud-sync/).
+Services like [[Introduction to Obsidian Sync|Obsidian Sync]], iCloud, OneDrive, and Dropbox sync your notes across devices. They may offer [[Version history|note restoration]], but they are [**not** designed to back up](https://www.backblaze.com/blog/cloud-backup-vs-cloud-sync/) your vault.
 
 - **Sync:** Keeps files and data consistently updated across multiple devices. Changes in one location automatically reflect in all synced locations.
 - **Backup:** Saves copies of data in a separate location for recovery in case of data loss, corruption, or disaster. Backups are not for real-time access or collaboration.


### PR DESCRIPTION
The link text was "back up your vault", which isn't what the article is about. I shifted the boundaries to instead encompass "not designed to backup" (I left out "your vault" to avoid the impression that the issue is specific to Obsidian vaults).