### PR TITLE
Update `Properties` and `CSS snippets`

### DIFF
--- a/en/Editing and formatting/Properties.md
+++ b/en/Editing and formatting/Properties.md
@@ -65,12 +65,16 @@ You can change how properties are displayed in your note by going to  **Settings
 - **Hidden** — hides properties, can still be displayed in the sidebar via [[Properties view]].
 - **Source** — displays properties in plain text YAML format.
 
+### CSS snippets
+
+You can change the appearance of one or several notes of your choosing with [[CSS snippets]]
+
 ### Not supported
 
 A few features are not supported in Obsidian:
 
-- **Nested properties** — to view nested properties we recommend using the Source display.
-- **Bulk editing properties** — this can be achieved with community-made tools such as Python scripts.
+- **Nested properties** — to view nested properties, we recommend using the Source display.
+- **Bulk-editing properties** — this can be achieved with bulk-editing tools like VSCode, scripts and community plugins.
 - **Markdown in properties** — this is an intentional limitation as properties are meant for small, atomic bits of information that are both human and machine readable.
 
 ## Hotkeys
@@ -124,7 +128,7 @@ When a property is focused
 
 ## Property format
 
-Properties are stored in [YAML](https://yaml.org/)  format at the top of the file. YAML is a widely used format that's readable by both humans and machines.
+Properties are stored in [YAML](https://yaml.org/)  format at the top of the file. YAML is a widely-used format that's readable by both humans and machines.
 
 Property names are separated from their values by a colon followed by a space:
 

--- a/en/Extending Obsidian/CSS snippets.md
+++ b/en/Extending Obsidian/CSS snippets.md
@@ -8,9 +8,11 @@ Learn how to modify aspects of the Obsidian application's appearance without nee
 
 > [!tip] If you're looking for guidance on handling CSS for [[Introduction to Obsidian Publish|Obsidian Publish]], be sure to review [[Customize your site]].
 
-CSS is a language to describe how to present a HTML document. By adding CSS snippets, you can redefine parts of the Obsidian user interface, such as the size and color of headings. Obsidian includes [CSS variables](https://docs.obsidian.md/Reference/CSS+variables/CSS+variables) that you can use to easily customize parts of the interface.
+CSS is a language to describe how to present HTML. By adding CSS snippets, you can redefine parts of the Obsidian user interface, such as the size and color of headings. Obsidian includes [CSS variables](https://docs.obsidian.md/Reference/CSS+variables/CSS+variables) that you can use to easily customize parts of the interface.
 
-Obsidian looks for CSS snippets inside the vault [[Configuration folder]].
+Obsidian looks for CSS snippets inside the vault's [[Configuration folder|configuration folder]].
+
+## Adding a snippet
 
 To add a CSS snippet on **Desktop** ![[lucide-monitor-check.svg#icon]], follow these steps:
 
@@ -18,30 +20,66 @@ To add a CSS snippet on **Desktop** ![[lucide-monitor-check.svg#icon]], follow t
 2. Under **Appearance → CSS snippets**, select **Open snippets folder** ( ![[lucide-folder-plus.svg#icon]] ).
 3. In the snippets folder, create a CSS file that contains your snippet.
 4. In Obsidian, under **Appearance → CSS snippets**, select **Reload snippets** ( ![[lucide-refresh-cw.svg#icon]] ) to see the snippet in the list.
+5. Enable snippet by clicking the toggle.
 
-To add a CSS snippet on **Mobile/Tablet** ![[obsidian-smartphone.svg#icon]], you will need to do one of the following:
-- [[Sync your notes across devices|Sync]] any changes in from your syncing service.
-- Use a file manager to access the [[Configuration folder]], and place the `file.css` in the snippet folder. 
-- Use a community plugin to directly create a `file.css` from within Obsidian. 
+To add a CSS snippet on **Mobile/Tablet** ![[obsidian-smartphone.svg#icon]], you can follow these steps:
 
-Once done, you can reload the snippets the same way you do on Desktop. 
+1. Open a file manager and locate your vault. Its location can be determined in the *Manage vaults...* menu by tapping your vault and seeing the path.
+2. Open the [[Configuration folder]] and then open or create a folder called `snippets`.
+3. Add your CSS snippet to this folder.
+4. In Obsidian, under **Appearance → CSS snippets**, select **Reload snippets** ( ![[lucide-refresh-cw.svg#icon]] ) to see the snippet in the list.
+5. Enable snippet by tapping the toggle.
 
-Once loaded, Obsidian detects changes to CSS snippets automatically and applies them when you save your snippet. You don't need to restart Obsidian for changes to take effect.
+Alternately, you can
+- [[Sync your notes across devices|Sync]] any changes in with your syncing service.
+- Use a community plugin to create a snippet from within Obsidian. 
 
-> [!tip] Example: Change text color
-> For example, create a file called `snippet.css` with the following content to change the text color to red:
+
+Once enabled, Obsidian detects changes to CSS snippets automatically and applies them when you save the file. You don't need to restart Obsidian for changes to take effect.
+
+## Writing CSS for Obsidian
+
+Obsidian provides several methods that make writing CSS easier and more powerful.
+
+It has a host of [CSS variables](https://docs.obsidian.md/Reference/CSS+variables/CSS+variables) to easily modify parts of Obsidian and a built-in [[properties#Property types|property type]] to change the appearance of one or several notes.
+
+> [!tip] Example: Variables
+> Create a file called `snippet.css` with the following content to modify the six [[Basic formatting syntax#Headings|heading levels]] to a rainbow.
 >
 >
 >
 > ```css
 > body {
->   --text-normal: red;
+>   --h1-color: red;
+>   --h2-color: orange;
+>   --h3-color: yellow;
+>   --h4-color: green;
+>   --h5-color: blue;
+>   --h6-color: pink;
 > }
 > ```
+
+> [!tip] Example: CSSclasses
+> With a [[Properties|property]] name of `CSSclasses` and a value of whatever you like, you can make one or several notes different from one another.
+> 
+> CSS:
+> ```css
+> .no-inline .inline-title {
+>    display: none;
+> }
+> ```
+> 
+> YAML/Properties:
+> ```yaml
+> cssclasses: no-inline
+> ```
+> This hides the inline title from any note with this property and value.
 
 To ensure that the CSS file is valid and formatted correctly, we advise creating and editing it with a program like [Visual Studio Code](https://visualstudio.microsoft.com/) or [Sublime Text](https://www.sublimetext.com/), as invalid CSS will not work.
 
 ## Learn more
 
 - If you're new to CSS, refer to [Learn to style HTML using CSS](https://developer.mozilla.org/en-US/docs/Learn/CSS) by Mozilla.
-- If you want more tips on styling Obsidian, refer to [About styling](https://docs.obsidian.md/Reference/CSS+variables/About+styling).
+- If you'd like more information on styling Obsidian, refer to:
+	- [About styling](https://docs.obsidian.md/Reference/CSS+variables/About+styling)
+	- [Build a theme](https://docs.obsidian.md/Themes/App+themes/Build+a+theme)


### PR DESCRIPTION
Closes #831 

CSS snippets:
Elaborates on CSSclasses and variables, add two more pages to Learn more,  adds steps for mobile users on how to add snippets.

Properties:
Grammar fixes, add CSSclasses to Advanced uses section.

I should probably have read the style guide.