### PR TITLE
docs: Document support for optional extension in internal links

### DIFF
--- a/en/Linking notes and files/Internal links.md
+++ b/en/Linking notes and files/Internal links.md
@@ -20,8 +20,8 @@ Obsidian can automatically update internal links in your vault when you rename a
 
 Obsidian supports the following link formats:
 
-- Wikilink: `[[Three laws of motion]]`
-- Markdown: `[Three laws of motion](Three%20laws%20of%20motion.md)`
+- Wikilink: `[[Three laws of motion]]` (or with explicit extension `[[Three laws of motion.md]]`)
+- Markdown: `[Three laws of motion](Three%20laws%20of%20motion)` (or with explicit extension `[Three laws of motion](Three%20laws%20of%20motion.md)`)
 
 The examples above are equivalent—they appear the same way in the editor, and links to the same note.
 


### PR DESCRIPTION
From a discussion about links with `mnaoumov` it came to my attention that the documentation isn't complete. To verify, add the following into a note titled `minimal working example`, and you'll see that each link properly links to the note.

```
markdownlink with md: [MWE](_tmp/minimal%20working%20example.md)
markdownlink without md: [MWE](_tmp/minimal%20working%20example)
wikilink without md: [[minimal working example|MWE]]
wikilink with md: [[minimal working example.md|MWE]]
```

While this is a non-issue for most people, when asking for "parity with Obsidian's links" in a 3rd party plugin, it would be nice if the documentation accurately reflects the allowed formats in Obsidian.