### PR TITLE
Match the Linux install steps to the download page

### DIFF
--- a/en/Getting started/Download and install Obsidian.md
+++ b/en/Getting started/Download and install Obsidian.md
@@ -24,13 +24,23 @@ If you use Linux, you can install Obsidian in several ways. Follow the instructi
 
 ### Install Obsidian using Snap
 
-1. Open your browser and go to [Download Obsidian](https://obsidian.md/download).
-2. Under **Linux**, click **Snap** to download the installation file.
-3. Open a terminal and navigate to the folder where you downloaded the installation file.
-4. In the terminal, run the following command to install the Snap package: (the `--dangerous` flag is required because Canonical, the company who created Snap, didn't review our package, the `--classic` flag allows Obsidian to access outside of the sandbox, where your notes are stored)
+1. In your terminal, run the following command to install Obsidian from the Snap Store: (the `--classic` flag allows Obsidian to access outside of the sandbox, where your notes are stored)
 
    ```bash
-   snap install obsidian_<version>_<arch>.snap --dangerous --classic
+   snap install obsidian --classic
+   ```
+
+2. Open Obsidian the same way you would open any other application.
+
+### Install Obsidian using a Debian package
+
+1. Open your browser and go to [Download Obsidian](https://obsidian.md/download).
+2. Under **Linux**, click **Deb** to download the installation file.
+3. Open a terminal and navigate to the folder where you downloaded the installation file.
+4. In the terminal, run the following command to install the package:
+
+   ```bash
+   sudo apt install ./obsidian_<version>_amd64.deb
    ```
 
 5. Open Obsidian the same way you would open any other application.


### PR DESCRIPTION
Closes #973.

The Linux section listed Snap, AppImage, and Flatpak. Checked against [Download Obsidian](https://obsidian.md/download), which currently offers four Linux options, labelled `AppImage`, `AppImage (AArch64, ARM64)`, `Snap`, `Deb`, plus a community Flatpak. Two of them were out of sync.

## Snap: the steps cannot be followed as written

The page said to click **Snap** to download an installation file, then:

```bash
snap install obsidian_<version>_<arch>.snap --dangerous --classic
```

The **Snap** button opens <https://snapcraft.io/obsidian>, the Snap Store — it does not download a file. And no `.snap` asset has been published in [obsidian-releases](https://github.com/obsidianmd/obsidian-releases/releases) since `v1.9.14`; every desktop release from `v1.10.3` to `v1.13.7` ships `.AppImage`, `.tar.gz`, and `.deb` only. So a reader following steps 2 to 4 has no file to install.

Replaced with the store install the Snap Store page itself lists:

```bash
snap install obsidian --classic
```

`--dangerous` is dropped because it only applies to sideloading an unreviewed local file. The `--classic` explanation is kept as it was, since it is still required and still worth stating.

## Deb: offered but undocumented

`obsidian_<version>_amd64.deb` is linked from the download page under the **Deb** label and ships with every desktop release, but the page had no instructions for it. Added a section in the same shape as the others.

## Scope

`en` only, so `/scripts` can propagate to the other locales as the contributing README describes. `.tar.gz` is deliberately left out: it ships in releases but the download page does not offer it, and this change is about matching the page.

## Verification

- Every claim above re-checked today against the live download page, the Snap Store listing, and the last twelve releases.
- Button labels quoted exactly as they appear on the download page.
- Markdown: code fences balanced, no wikilinks introduced, step numbering contiguous in both edited sections, no malformed links, `git diff --check` clean.
- I did not run the install commands themselves; `snap install obsidian --classic` is quoted from the Snap Store page and `sudo apt install ./<file>.deb` is the standard local-package invocation.
